### PR TITLE
Query support and upgrade to Buzzard release

### DIFF
--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -5,16 +5,16 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = errorHandler;
 
-var _feathersErrors = require('feathers-errors');
+var _errors = require('@feathersjs/errors');
 
-var _feathersErrors2 = _interopRequireDefault(_feathersErrors);
+var _errors2 = _interopRequireDefault(_errors);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function errorHandler(error) {
   let feathersError = error;
   if (error.name === 'CouchError') {
-    const ErrorType = error.code === 404 || error.headers.status === 404 ? _feathersErrors2.default.NotFound : _feathersErrors2.default.GeneralError;
+    const ErrorType = error.code === 404 || error.headers.status === 404 ? _errors2.default.NotFound : _errors2.default.GeneralError;
     feathersError = new ErrorType(error, {
       ok: error.ok,
       code: error.code

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
-    value: true
+  value: true
 });
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
@@ -29,165 +29,165 @@ var _util = require('./util');
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 const removeInvalidParams = params => {
-    const allowedParams = ['selector', 'limit', 'skip', 'sort', 'fields', 'use_index', 'r', 'bookmark', 'update', 'stable', 'stale', 'execution_stats', 'conflicts', 'descending', 'endkey', 'end_key', 'endkey_docid', 'end_key_doc_id', 'include_docs', 'inclusive_end', 'key', 'keys', 'startkey', 'start_key', 'startkey_docid', 'start_key_doc_id', 'update_seq', 'options', 'filters', 'lists', 'rewrites', 'shows', 'updates', 'validate_doc_update', 'views'];
-    return (0, _util.filterByKeys)(allowedParams, params);
+  const allowedParams = ['selector', 'limit', 'skip', 'sort', 'fields', 'use_index', 'r', 'bookmark', 'update', 'stable', 'stale', 'execution_stats', 'conflicts', 'descending', 'endkey', 'end_key', 'endkey_docid', 'end_key_doc_id', 'include_docs', 'inclusive_end', 'key', 'keys', 'startkey', 'start_key', 'startkey_docid', 'start_key_doc_id', 'update_seq', 'options', 'filters', 'lists', 'rewrites', 'shows', 'updates', 'validate_doc_update', 'views'];
+  return (0, _util.filterByKeys)(allowedParams, params);
 };
 
 const _mapQueryParams = params => {
-    let mappedParams = Object.assign({}, params);
-    if (mappedParams.query) {
-        mappedParams.selector = mappedParams.query;
-    } else {
-        return mappedParams;
-    }
-    if (mappedParams.selector.$limit) {
-        mappedParams.limit = mappedParams.selector.$limit;
-    }
-    if (mappedParams.selector.$skip) {
-        mappedParams.skip = mappedParams.selector.$skip;
-    }
-    if (mappedParams.selector.$sort) {
-        mappedParams.sort = mappedParams.selector.$sort;
-    }
-    if (mappedParams.selector.$select) {
-        mappedParams.fields = mappedParams.selector.$select;
-    }
+  let mappedParams = Object.assign({}, params);
+  if (mappedParams.query) {
+    mappedParams.selector = mappedParams.query;
+  } else {
     return mappedParams;
+  }
+  if (mappedParams.selector.$limit) {
+    mappedParams.limit = mappedParams.selector.$limit;
+  }
+  if (mappedParams.selector.$skip) {
+    mappedParams.skip = mappedParams.selector.$skip;
+  }
+  if (mappedParams.selector.$sort) {
+    mappedParams.sort = mappedParams.selector.$sort;
+  }
+  if (mappedParams.selector.$select) {
+    mappedParams.fields = mappedParams.selector.$select;
+  }
+  return mappedParams;
 };
 
 class Service {
-    constructor(options) {
-        if (!options) {
-            throw new Error('CouchDB options have to be provided');
-        }
-
-        if (!('connection' in options)) {
-            throw new Error('You must provide CouchDB connection');
-        }
-
-        if (!('database' in options)) {
-            throw new Error('You must provide a database name');
-        }
-
-        this.connection = options.connection;
-        this.database = options.database;
-        this.paginate = options.paginate || {};
-
-        const create = _bluebird2.default.promisify(this.connection.db.create);
-        const get = _bluebird2.default.promisify(this.connection.db.get);
-
-        this.db = get(options.database).catch(() => create(options.database)).catch(() => true) // always invoke next then
-        .then(() => _bluebird2.default.promisifyAll(this.connection.use(options.database)));
+  constructor(options) {
+    if (!options) {
+      throw new Error('CouchDB options have to be provided');
     }
 
-    extend(obj) {
-        return _uberproto2.default.extend(obj, this);
+    if (!('connection' in options)) {
+      throw new Error('You must provide CouchDB connection');
     }
 
-    _list(params) {
-        return this.db.then(db => db.listAsync(params));
+    if (!('database' in options)) {
+      throw new Error('You must provide a database name');
     }
 
-    _view(designname, viewname, params) {
-        return this.db.then(db => db.viewAsync(designname, viewname, params));
-    }
+    this.connection = options.connection;
+    this.database = options.database;
+    this.paginate = options.paginate || {};
 
-    _selector(params) {
-        return _bluebird2.default.promisify(this.connection.request)({
-            method: 'POST',
-            doc: '_find',
-            db: this.database,
-            body: params
-        });
-    }
+    const create = _bluebird2.default.promisify(this.connection.db.create);
+    const get = _bluebird2.default.promisify(this.connection.db.get);
 
-    _get(id, params) {
-        return this.db.then(db => db.getAsync(id, params));
-    }
+    this.db = get(options.database).catch(() => create(options.database)).catch(() => true) // always invoke next then
+    .then(() => _bluebird2.default.promisifyAll(this.connection.use(options.database)));
+  }
 
-    _insert(doc, params) {
-        return this.db.then(db => db.insertAsync(doc, params)).then(res => Object.assign(doc, { _id: res.id, _rev: res.rev }));
-    }
+  extend(obj) {
+    return _uberproto2.default.extend(obj, this);
+  }
 
-    _bulk(docs, params) {
-        const assign = (data, res) => Object.assign(data, { _id: res.id, _rev: res.rev });
-        const bulkAssign = (arr, res) => arr.map((data, index) => assign(data, res[index]));
-        return this.db.then(db => db.bulkAsync({ docs }, params)).then(res => bulkAssign(docs, res));
-    }
+  _list(params) {
+    return this.db.then(db => db.listAsync(params));
+  }
 
-    _destroy(id, rev) {
-        return this.db.then(db => db.destroyAsync(id, rev));
-    }
+  _view(designname, viewname, params) {
+    return this.db.then(db => db.viewAsync(designname, viewname, params));
+  }
 
-    /**
-     * @param params
-     * @returns {object} {
+  _selector(params) {
+    return _bluebird2.default.promisify(this.connection.request)({
+      method: 'POST',
+      doc: '_find',
+      db: this.database,
+      body: params
+    });
+  }
+
+  _get(id, params) {
+    return this.db.then(db => db.getAsync(id, params));
+  }
+
+  _insert(doc, params) {
+    return this.db.then(db => db.insertAsync(doc, params)).then(res => Object.assign(doc, { _id: res.id, _rev: res.rev }));
+  }
+
+  _bulk(docs, params) {
+    const assign = (data, res) => Object.assign(data, { _id: res.id, _rev: res.rev });
+    const bulkAssign = (arr, res) => arr.map((data, index) => assign(data, res[index]));
+    return this.db.then(db => db.bulkAsync({ docs }, params)).then(res => bulkAssign(docs, res));
+  }
+
+  _destroy(id, rev) {
+    return this.db.then(db => db.destroyAsync(id, rev));
+  }
+
+  /**
+   * @param params
+   * @returns {object} {
     "data": "<Array>"
     "total": "<total number of records>",
     "limit": "<max number of items per page>",
     "skip": "<number of skipped items (offset)>",
     "bookmark": "<alternative to skip>"
     }
-     */
-    find(parameters = {}) {
-        let params = _mapQueryParams(parameters);
-        params.limit = params.limit || this.paginate.default;
+   */
+  find(parameters = {}) {
+    let params = _mapQueryParams(parameters);
+    params.limit = params.limit || this.paginate.default;
 
-        const selector = params => {
-            return this._selector(removeInvalidParams(params)).then(res => ({
-                limit: params.limit,
-                bookmark: res.bookmark,
-                data: res.docs
-            }));
-        };
+    const selector = params => {
+      return this._selector(removeInvalidParams(params)).then(res => ({
+        limit: params.limit,
+        bookmark: res.bookmark,
+        data: res.docs
+      }));
+    };
 
-        const view = params => {
-            return this._view(params.view.split('/')[0], params.view.split('/')[1], removeInvalidParams(params));
-        };
+    const view = params => {
+      return this._view(params.view.split('/')[0], params.view.split('/')[1], removeInvalidParams(params));
+    };
 
-        const list = params => {
-            return this._list(removeInvalidParams(params));
-        };
+    const list = params => {
+      return this._list(removeInvalidParams(params));
+    };
 
-        const viewOrList = params => {
-            return (params.view ? view(query) : list(_extends({}, params, { include_docs: true }))).then(res => ({
-                total: res.total_rows,
-                limit: params.limit,
-                skip: res.offset - 1,
-                data: res.rows.map(row => row.doc)
-            }));
-        };
+    const viewOrList = params => {
+      return (params.view ? view(query) : list(_extends({}, params, { include_docs: true }))).then(res => ({
+        total: res.total_rows,
+        limit: params.limit,
+        skip: res.offset - 1,
+        data: res.rows.map(row => row.doc)
+      }));
+    };
 
-        return (params.selector ? selector(params) : viewOrList(params)).catch(_errorHandler2.default);
+    return (params.selector ? selector(params) : viewOrList(params)).catch(_errorHandler2.default);
+  }
+
+  get(id, params = {}) {
+    return this._get(id, removeInvalidParams(params)).catch(_errorHandler2.default);
+  }
+
+  create(data, params = {}) {
+    return (Array.isArray(data) ? this._bulk(data, removeInvalidParams(params)) : this._insert(data, removeInvalidParams(params))).catch(_errorHandler2.default);
+  }
+
+  update(id, data, params = { include_docs: false }) {
+    if (Array.isArray(data) || id === null) {
+      return _bluebird2.default.reject(new _errors2.default.BadRequest('Not replacing multiple records. Did you mean `patch`?'));
     }
 
-    get(id, params = {}) {
-        return this._get(id, removeInvalidParams(params)).catch(_errorHandler2.default);
-    }
+    return this._get(id, removeInvalidParams(params)).then(doc => (Object.assign(data, { _rev: doc._rev }), this._insert(data, id).then(() => data))).catch(_errorHandler2.default);
+  }
 
-    create(data, params = {}) {
-        return (Array.isArray(data) ? this._bulk(data, removeInvalidParams(params)) : this._insert(data, removeInvalidParams(params))).catch(_errorHandler2.default);
-    }
+  patch(id, data, params = {}) {
+    return this._get(id, removeInvalidParams(params)).then(doc => ((0, _util.mergeDeep)(doc, data), this._insert(doc, id))).catch(_errorHandler2.default);
+  }
 
-    update(id, data, params = { include_docs: false }) {
-        if (Array.isArray(data) || id === null) {
-            return _bluebird2.default.reject(new _errors2.default.BadRequest('Not replacing multiple records. Did you mean `patch`?'));
-        }
-
-        return this._get(id, removeInvalidParams(params)).then(doc => (Object.assign(data, { _rev: doc._rev }), this._insert(data, id).then(() => data))).catch(_errorHandler2.default);
-    }
-
-    patch(id, data, params = {}) {
-        return this._get(id, removeInvalidParams(params)).then(doc => ((0, _util.mergeDeep)(doc, data), this._insert(doc, id))).catch(_errorHandler2.default);
-    }
-
-    remove(id, params = {}) {
-        return this._get(id, removeInvalidParams(params)).then(doc => this._destroy(doc._id, doc._rev)).catch(_errorHandler2.default);
-    }
+  remove(id, params = {}) {
+    return this._get(id, removeInvalidParams(params)).then(doc => this._destroy(doc._id, doc._rev)).catch(_errorHandler2.default);
+  }
 }
 
 function init(options) {
-    return new Service(options);
+  return new Service(options);
 }
 
 init.Service = Service;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
-  value: true
+    value: true
 });
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
@@ -16,9 +16,9 @@ var _uberproto = require('uberproto');
 
 var _uberproto2 = _interopRequireDefault(_uberproto);
 
-var _feathersErrors = require('feathers-errors');
+var _errors = require('@feathersjs/errors');
 
-var _feathersErrors2 = _interopRequireDefault(_feathersErrors);
+var _errors2 = _interopRequireDefault(_errors);
 
 var _errorHandler = require('./error-handler');
 
@@ -29,142 +29,162 @@ var _util = require('./util');
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 const removeInvalidParams = params => {
-  const allowedParams = ['selector', 'limit', 'skip', 'sort', 'fields', 'use_index', 'r', 'bookmark', 'update', 'stable', 'stale', 'execution_stats', 'conflicts', 'descending', 'endkey', 'end_key', 'endkey_docid', 'end_key_doc_id', 'include_docs', 'inclusive_end', 'key', 'keys', 'startkey', 'start_key', 'startkey_docid', 'start_key_doc_id', 'update_seq', 'options', 'filters', 'lists', 'rewrites', 'shows', 'updates', 'validate_doc_update', 'views'];
-  return (0, _util.filterByKeys)(allowedParams, params);
+    const allowedParams = ['selector', 'limit', 'skip', 'sort', 'fields', 'use_index', 'r', 'bookmark', 'update', 'stable', 'stale', 'execution_stats', 'conflicts', 'descending', 'endkey', 'end_key', 'endkey_docid', 'end_key_doc_id', 'include_docs', 'inclusive_end', 'key', 'keys', 'startkey', 'start_key', 'startkey_docid', 'start_key_doc_id', 'update_seq', 'options', 'filters', 'lists', 'rewrites', 'shows', 'updates', 'validate_doc_update', 'views'];
+    return (0, _util.filterByKeys)(allowedParams, params);
+};
+
+const _mapQueryParams = params => {
+    let mappedParams = Object.assign({}, params);
+    if (mappedParams.query) {
+        mappedParams.selector = mappedParams.query;
+    }
+    if (mappedParams.selector.$limit) {
+        mappedParams.limit = mappedParams.selector.$limit;
+    }
+    if (mappedParams.selector.$skip) {
+        mappedParams.skip = mappedParams.selector.$skip;
+    }
+    if (mappedParams.selector.$sort) {
+        mappedParams.sort = mappedParams.selector.$sort;
+    }
+    if (mappedParams.selector.$select) {
+        mappedParams.fields = mappedParams.selector.$select;
+    }
+    return mappedParams;
 };
 
 class Service {
-  constructor(options) {
-    if (!options) {
-      throw new Error('CouchDB options have to be provided');
+    constructor(options) {
+        if (!options) {
+            throw new Error('CouchDB options have to be provided');
+        }
+
+        if (!('connection' in options)) {
+            throw new Error('You must provide CouchDB connection');
+        }
+
+        if (!('database' in options)) {
+            throw new Error('You must provide a database name');
+        }
+
+        this.connection = options.connection;
+        this.database = options.database;
+        this.paginate = options.paginate || {};
+
+        const create = _bluebird2.default.promisify(this.connection.db.create);
+        const get = _bluebird2.default.promisify(this.connection.db.get);
+
+        this.db = get(options.database).catch(() => create(options.database)).catch(() => true) // always invoke next then
+        .then(() => _bluebird2.default.promisifyAll(this.connection.use(options.database)));
     }
 
-    if (!('connection' in options)) {
-      throw new Error('You must provide CouchDB connection');
+    extend(obj) {
+        return _uberproto2.default.extend(obj, this);
     }
 
-    if (!('database' in options)) {
-      throw new Error('You must provide a database name');
+    _list(params) {
+        return this.db.then(db => db.listAsync(params));
     }
 
-    this.connection = options.connection;
-    this.database = options.database;
-    this.paginate = options.paginate || {};
-
-    const create = _bluebird2.default.promisify(this.connection.db.create);
-    const get = _bluebird2.default.promisify(this.connection.db.get);
-
-    this.db = get(options.database).catch(() => create(options.database)).catch(() => true) // always invoke next then
-    .then(() => _bluebird2.default.promisifyAll(this.connection.use(options.database)));
-  }
-
-  extend(obj) {
-    return _uberproto2.default.extend(obj, this);
-  }
-
-  _list(params) {
-    return this.db.then(db => db.listAsync(params));
-  }
-
-  _view(designname, viewname, params) {
-    return this.db.then(db => db.viewAsync(designname, viewname, params));
-  }
-
-  _selector(params) {
-    return _bluebird2.default.promisify(this.connection.request)({
-      method: 'POST',
-      doc: '_find',
-      db: this.database,
-      body: params
-    });
-  }
-
-  _get(id, params) {
-    return this.db.then(db => db.getAsync(id, params));
-  }
-
-  _insert(doc, params) {
-    return this.db.then(db => db.insertAsync(doc, params)).then(res => Object.assign(doc, { _id: res.id, _rev: res.rev }));
-  }
-
-  _bulk(docs, params) {
-    const assign = (data, res) => Object.assign(data, { _id: res.id, _rev: res.rev });
-    const bulkAssign = (arr, res) => arr.map((data, index) => assign(data, res[index]));
-    return this.db.then(db => db.bulkAsync({ docs }, params)).then(res => bulkAssign(docs, res));
-  }
-
-  _destroy(id, rev) {
-    return this.db.then(db => db.destroyAsync(id, rev));
-  }
-
-  /**
-   * @param params
-   * @returns {object} {
-      "data": "<Array>"
-      "total": "<total number of records>",
-      "limit": "<max number of items per page>",
-      "skip": "<number of skipped items (offset)>",
-      "bookmark": "<alternative to skip>"
-      }
-  */
-  find(params = {}) {
-    params.limit = params.limit || this.paginate.default;
-
-    const selector = params => {
-      return this._selector(removeInvalidParams(params)).then(res => ({
-        limit: params.limit,
-        bookmark: res.bookmark,
-        data: res.docs
-      }));
-    };
-
-    const view = params => {
-      return this._view(params.view.split('/')[0], params.view.split('/')[1], removeInvalidParams(params));
-    };
-
-    const list = params => {
-      return this._list(removeInvalidParams(params));
-    };
-
-    const viewOrList = params => {
-      return (params.view ? view(query) : list(_extends({}, params, { include_docs: true }))).then(res => ({
-        total: res.total_rows,
-        limit: params.limit,
-        skip: res.offset - 1,
-        data: res.rows.map(row => row.doc)
-      }));
-    };
-
-    return (params.selector ? selector(params) : viewOrList(params)).catch(_errorHandler2.default);
-  }
-
-  get(id, params = {}) {
-    return this._get(id, removeInvalidParams(params)).catch(_errorHandler2.default);
-  }
-
-  create(data, params = {}) {
-    return (Array.isArray(data) ? this._bulk(data, removeInvalidParams(params)) : this._insert(data, removeInvalidParams(params))).catch(_errorHandler2.default);
-  }
-
-  update(id, data, params = { include_docs: false }) {
-    if (Array.isArray(data) || id === null) {
-      return _bluebird2.default.reject(new _feathersErrors2.default.BadRequest('Not replacing multiple records. Did you mean `patch`?'));
+    _view(designname, viewname, params) {
+        return this.db.then(db => db.viewAsync(designname, viewname, params));
     }
 
-    return this._get(id, removeInvalidParams(params)).then(doc => (Object.assign(data, { _rev: doc._rev }), this._insert(data, id).then(() => data))).catch(_errorHandler2.default);
-  }
+    _selector(params) {
+        return _bluebird2.default.promisify(this.connection.request)({
+            method: 'POST',
+            doc: '_find',
+            db: this.database,
+            body: params
+        });
+    }
 
-  patch(id, data, params = {}) {
-    return this._get(id, removeInvalidParams(params)).then(doc => ((0, _util.mergeDeep)(doc, data), this._insert(doc, id))).catch(_errorHandler2.default);
-  }
+    _get(id, params) {
+        return this.db.then(db => db.getAsync(id, params));
+    }
 
-  remove(id, params = {}) {
-    return this._get(id, removeInvalidParams(params)).then(doc => this._destroy(doc._id, doc._rev)).catch(_errorHandler2.default);
-  }
+    _insert(doc, params) {
+        return this.db.then(db => db.insertAsync(doc, params)).then(res => Object.assign(doc, { _id: res.id, _rev: res.rev }));
+    }
+
+    _bulk(docs, params) {
+        const assign = (data, res) => Object.assign(data, { _id: res.id, _rev: res.rev });
+        const bulkAssign = (arr, res) => arr.map((data, index) => assign(data, res[index]));
+        return this.db.then(db => db.bulkAsync({ docs }, params)).then(res => bulkAssign(docs, res));
+    }
+
+    _destroy(id, rev) {
+        return this.db.then(db => db.destroyAsync(id, rev));
+    }
+
+    /**
+     * @param params
+     * @returns {object} {
+    "data": "<Array>"
+    "total": "<total number of records>",
+    "limit": "<max number of items per page>",
+    "skip": "<number of skipped items (offset)>",
+    "bookmark": "<alternative to skip>"
+    }
+     */
+    find(params = {}) {
+        params.limit = params.limit || this.paginate.default;
+
+        const selector = params => {
+            return this._selector(removeInvalidParams(_mapQueryParams(params))).then(res => ({
+                limit: params.limit,
+                bookmark: res.bookmark,
+                data: res.docs
+            }));
+        };
+
+        const view = params => {
+            return this._view(params.view.split('/')[0], params.view.split('/')[1], removeInvalidParams(params));
+        };
+
+        const list = params => {
+            return this._list(removeInvalidParams(params));
+        };
+
+        const viewOrList = params => {
+            return (params.view ? view(query) : list(_extends({}, params, { include_docs: true }))).then(res => ({
+                total: res.total_rows,
+                limit: params.limit,
+                skip: res.offset - 1,
+                data: res.rows.map(row => row.doc)
+            }));
+        };
+
+        return (params.selector ? selector(params) : viewOrList(params)).catch(_errorHandler2.default);
+    }
+
+    get(id, params = {}) {
+        return this._get(id, removeInvalidParams(params)).catch(_errorHandler2.default);
+    }
+
+    create(data, params = {}) {
+        return (Array.isArray(data) ? this._bulk(data, removeInvalidParams(params)) : this._insert(data, removeInvalidParams(params))).catch(_errorHandler2.default);
+    }
+
+    update(id, data, params = { include_docs: false }) {
+        if (Array.isArray(data) || id === null) {
+            return _bluebird2.default.reject(new _errors2.default.BadRequest('Not replacing multiple records. Did you mean `patch`?'));
+        }
+
+        return this._get(id, removeInvalidParams(params)).then(doc => (Object.assign(data, { _rev: doc._rev }), this._insert(data, id).then(() => data))).catch(_errorHandler2.default);
+    }
+
+    patch(id, data, params = {}) {
+        return this._get(id, removeInvalidParams(params)).then(doc => ((0, _util.mergeDeep)(doc, data), this._insert(doc, id))).catch(_errorHandler2.default);
+    }
+
+    remove(id, params = {}) {
+        return this._get(id, removeInvalidParams(params)).then(doc => this._destroy(doc._id, doc._rev)).catch(_errorHandler2.default);
+    }
 }
 
 function init(options) {
-  return new Service(options);
+    return new Service(options);
 }
 
 init.Service = Service;

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,6 +37,8 @@ const _mapQueryParams = params => {
     let mappedParams = Object.assign({}, params);
     if (mappedParams.query) {
         mappedParams.selector = mappedParams.query;
+    } else {
+        return mappedParams;
     }
     if (mappedParams.selector.$limit) {
         mappedParams.limit = mappedParams.selector.$limit;

--- a/lib/index.js
+++ b/lib/index.js
@@ -129,11 +129,12 @@ class Service {
     "bookmark": "<alternative to skip>"
     }
      */
-    find(params = {}) {
+    find(parameters = {}) {
+        let params = _mapQueryParams(parameters);
         params.limit = params.limit || this.paginate.default;
 
         const selector = params => {
-            return this._selector(removeInvalidParams(_mapQueryParams(params))).then(res => ({
+            return this._selector(removeInvalidParams(params)).then(res => ({
                 limit: params.limit,
                 bookmark: res.bookmark,
                 data: res.docs

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,45 +4,75 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@types/express": {
-      "version": "4.0.37",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.0.37.tgz",
-      "integrity": "sha512-tIULTLzQpFFs5/PKnFIAFOsXQxss76glppbVKR3/jddPK26SBsD5HF5grn5G2jOGtpRWSBvYmDYoduVv+3wOXg==",
-      "dev": true,
-      "requires": {
-        "@types/express-serve-static-core": "4.0.53",
-        "@types/serve-static": "1.7.32"
-      }
-    },
-    "@types/express-serve-static-core": {
-      "version": "4.0.53",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.0.53.tgz",
-      "integrity": "sha512-zaGeOpEYp5G2EhjaUFdVwysDrfEYc6Q6iPhd3Kl4ip30x0tvVv7SuJvY3yzCUSuFlzAG8N5KsyY6BJg93/cn+Q==",
-      "dev": true,
-      "requires": {
-        "@types/node": "8.0.28"
-      }
-    },
-    "@types/mime": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.0.tgz",
-      "integrity": "sha512-A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA==",
+    "@feathersjs/commons": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@feathersjs/commons/-/commons-1.4.0.tgz",
+      "integrity": "sha512-21/E+KpFJO32fK8snn9kVCWi7R3C2CEPUsuxgYg61mKqydXBvo0lDzMfhp//o4pu9rdZrvNSGyb32Gvi3eK3OA==",
       "dev": true
     },
-    "@types/node": {
-      "version": "8.0.28",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.28.tgz",
-      "integrity": "sha512-HupkFXEv3O3KSzcr3Ylfajg0kaerBg1DyaZzRBBQfrU3NN1mTBRE7sCveqHwXLS5Yrjvww8qFzkzYQQakG9FuQ==",
-      "dev": true
+    "@feathersjs/errors": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@feathersjs/errors/-/errors-3.2.2.tgz",
+      "integrity": "sha512-j2SiZBUimcUAFXGnmiByQKV+8/OehnJFGP5wT3XKjU6nyiLft6Av5ti1/sRV+ji2Tu80H6YVfhIoVG8ndEpBnA==",
+      "requires": {
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
     },
-    "@types/serve-static": {
-      "version": "1.7.32",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.7.32.tgz",
-      "integrity": "sha512-WpI0g7M1FiOmJ/a97Qrjafq2I938tjAZ3hZr9O7sXyA6oUhH3bqUNZIt7r1KZg8TQAKxcvxt6JjQ5XuLfIBFvg==",
+    "@feathersjs/express": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@feathersjs/express/-/express-1.1.2.tgz",
+      "integrity": "sha512-oxXZs3QAZB80fBajb7nh3Pbongm8ESXVnJw1EuX7fui4JOXh2qGw9hf8e3xKAZ/fmkHmgofdA1A3iqIzBg3Isw==",
       "dev": true,
       "requires": {
-        "@types/express-serve-static-core": "4.0.53",
-        "@types/mime": "2.0.0"
+        "@feathersjs/commons": "1.4.0",
+        "@feathersjs/errors": "3.2.2",
+        "debug": "3.1.0",
+        "express": "4.16.2",
+        "uberproto": "1.2.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "@feathersjs/feathers": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@feathersjs/feathers/-/feathers-3.1.0.tgz",
+      "integrity": "sha512-Ug8dhvxmsotQuRUf/fKxjSXLCH2D71+eaO6uOeJ5VEkqeGxg40AIwnHjP02Uxh1Tf2ON89S0OSq253G2hxsnIw==",
+      "dev": true,
+      "requires": {
+        "@feathersjs/commons": "1.4.0",
+        "debug": "3.1.0",
+        "events": "1.1.1",
+        "uberproto": "1.2.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "accepts": {
@@ -1504,9 +1534,9 @@
       "dev": true
     },
     "encodeurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
-      "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
     },
     "encoding": {
@@ -1892,54 +1922,74 @@
       }
     },
     "express": {
-      "version": "4.15.4",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.15.4.tgz",
-      "integrity": "sha1-Ay4iU0ic+PzgJma+yj0R7XotrtE=",
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
+      "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
       "dev": true,
       "requires": {
         "accepts": "1.3.4",
         "array-flatten": "1.1.1",
+        "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
         "content-type": "1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "depd": "1.1.1",
-        "encodeurl": "1.0.1",
+        "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "etag": "1.8.1",
-        "finalhandler": "1.0.5",
-        "fresh": "0.5.0",
+        "finalhandler": "1.1.0",
+        "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
         "methods": "1.1.2",
         "on-finished": "2.3.0",
         "parseurl": "1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "1.1.5",
-        "qs": "6.5.0",
+        "proxy-addr": "2.0.2",
+        "qs": "6.5.1",
         "range-parser": "1.2.0",
-        "send": "0.15.4",
-        "serve-static": "1.12.4",
-        "setprototypeof": "1.0.3",
+        "safe-buffer": "5.1.1",
+        "send": "0.16.1",
+        "serve-static": "1.13.1",
+        "setprototypeof": "1.1.0",
         "statuses": "1.3.1",
         "type-is": "1.6.15",
-        "utils-merge": "1.0.0",
-        "vary": "1.1.1"
+        "utils-merge": "1.0.1",
+        "vary": "1.1.2"
       },
       "dependencies": {
+        "body-parser": {
+          "version": "1.18.2",
+          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+          "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+          "dev": true,
+          "requires": {
+            "bytes": "3.0.0",
+            "content-type": "1.0.4",
+            "debug": "2.6.9",
+            "depd": "1.1.1",
+            "http-errors": "1.6.2",
+            "iconv-lite": "0.4.19",
+            "on-finished": "2.3.0",
+            "qs": "6.5.1",
+            "raw-body": "2.3.2",
+            "type-is": "1.6.15"
+          }
+        },
         "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
         },
-        "qs": {
-          "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
-          "integrity": "sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg==",
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
           "dev": true
         }
       }
@@ -2009,69 +2059,6 @@
         }
       }
     },
-    "feathers": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/feathers/-/feathers-2.2.0.tgz",
-      "integrity": "sha512-jSe3l6s6ez1kUCpg8E2nTdXsgSdps+juc0dH9/NMNRYAd1QgHuKPF1yN2HdcF6Woyva5OsI31+DMG46IAnd0uw==",
-      "dev": true,
-      "requires": {
-        "@types/express": "4.0.37",
-        "babel-runtime": "6.26.0",
-        "debug": "3.0.1",
-        "events": "1.1.1",
-        "express": "4.15.4",
-        "feathers-commons": "0.8.7",
-        "rubberduck": "1.1.1",
-        "uberproto": "1.2.0"
-      }
-    },
-    "feathers-commons": {
-      "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/feathers-commons/-/feathers-commons-0.8.7.tgz",
-      "integrity": "sha1-EcbyW1N3RamD6NYVUtfbiTLVN4I=",
-      "dev": true
-    },
-    "feathers-errors": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/feathers-errors/-/feathers-errors-2.9.2.tgz",
-      "integrity": "sha512-qwIX97bNW7+1tWVG073+omUA0rCYKJtTtwuzTrrvfrtdr8J8Dk1Fy4iaV9Fa6/YBD5AZu0lsplPE0iu4u/d4GQ==",
-      "requires": {
-        "debug": "3.0.1"
-      }
-    },
-    "feathers-hooks": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/feathers-hooks/-/feathers-hooks-2.0.2.tgz",
-      "integrity": "sha512-uhopRXldCE6BE61KjkDCmGbd9hRSNUJQiiX5td0+KRij7s24kCGjeMgM968YDsBm6DHrwIGwEG1ZPpEwfSvT2w==",
-      "dev": true,
-      "requires": {
-        "feathers-commons": "0.8.7",
-        "uberproto": "1.2.0"
-      }
-    },
-    "feathers-rest": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/feathers-rest/-/feathers-rest-1.8.0.tgz",
-      "integrity": "sha512-HLkmwJO4YqEpp7LRE7PbDjVmB03CS8KXqGslxsiQgyQ+bD3g2tGIhc0O9r2yQt4HD/QFNpi9jtWe05dS1PnAVA==",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.8",
-        "feathers-commons": "0.8.7",
-        "feathers-errors": "2.9.2",
-        "qs": "6.5.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
     "feathers-service-tests": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/feathers-service-tests/-/feathers-service-tests-0.10.2.tgz",
@@ -2124,13 +2111,13 @@
       }
     },
     "finalhandler": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.5.tgz",
-      "integrity": "sha1-pwEwPSV6G8gv6lR6M+WuiVMXI98=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+      "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
       "dev": true,
       "requires": {
-        "debug": "2.6.8",
-        "encodeurl": "1.0.1",
+        "debug": "2.6.9",
+        "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "on-finished": "2.3.0",
         "parseurl": "1.3.2",
@@ -2139,9 +2126,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -2216,9 +2203,9 @@
       "dev": true
     },
     "fresh": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
-      "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44=",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true
     },
     "fs-readdir-recursive": {
@@ -3002,14 +2989,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -3018,6 +2997,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -3416,9 +3403,9 @@
       }
     },
     "ipaddr.js": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.4.0.tgz",
-      "integrity": "sha1-KWrKh4qCGBbluF0KKFqZvP9FgvA=",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
+      "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A=",
       "dev": true
     },
     "is-arrayish": {
@@ -3850,9 +3837,9 @@
       }
     },
     "mime": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-      "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
       "dev": true
     },
     "mime-db": {
@@ -4234,13 +4221,13 @@
       }
     },
     "proxy-addr": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz",
-      "integrity": "sha1-ccDuOxAt4/IC87ZPYI0XP8uhqRg=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
+      "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
       "dev": true,
       "requires": {
         "forwarded": "0.1.2",
-        "ipaddr.js": "1.4.0"
+        "ipaddr.js": "1.5.2"
       }
     },
     "pseudomap": {
@@ -4571,12 +4558,6 @@
         "glob": "7.1.2"
       }
     },
-    "rubberduck": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/rubberduck/-/rubberduck-1.1.1.tgz",
-      "integrity": "sha1-zSzaS4ZxeBNer8mVpxOE9fdD2wI=",
-      "dev": true
-    },
     "run-async": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
@@ -4613,20 +4594,20 @@
       "dev": true
     },
     "send": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.15.4.tgz",
-      "integrity": "sha1-mF+qPihLAnPHkzZKNcZze9k5Bbk=",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
+      "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
       "dev": true,
       "requires": {
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "depd": "1.1.1",
         "destroy": "1.0.4",
-        "encodeurl": "1.0.1",
+        "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "etag": "1.8.1",
-        "fresh": "0.5.0",
+        "fresh": "0.5.2",
         "http-errors": "1.6.2",
-        "mime": "1.3.4",
+        "mime": "1.4.1",
         "ms": "2.0.0",
         "on-finished": "2.3.0",
         "range-parser": "1.2.0",
@@ -4634,9 +4615,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -4645,15 +4626,15 @@
       }
     },
     "serve-static": {
-      "version": "1.12.4",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.4.tgz",
-      "integrity": "sha1-m2qpjutyU8Tu3Ewfb9vKYJkBqWE=",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
+      "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
       "dev": true,
       "requires": {
-        "encodeurl": "1.0.1",
+        "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "parseurl": "1.3.2",
-        "send": "0.15.4"
+        "send": "0.16.1"
       }
     },
     "set-immediate-shim": {
@@ -4785,15 +4766,6 @@
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -4819,6 +4791,15 @@
             "ansi-regex": "3.0.0"
           }
         }
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {
@@ -5006,9 +4987,9 @@
       "dev": true
     },
     "utils-merge": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-      "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true
     },
     "uuid": {
@@ -5036,9 +5017,9 @@
       }
     },
     "vary": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
-      "integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true
     },
     "verror": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kapmug/feathers-nano",
-  "version": "2.2.2",
+  "version": "3.0.0",
   "description": "A couchdb service for feathers",
   "main": "lib/",
   "scripts": {
@@ -42,12 +42,14 @@
     ]
   },
   "dependencies": {
+    "@feathersjs/errors": "^3.2.2",
     "bluebird": "^3.5.0",
     "cloudant-nano": "^6.7.0",
-    "feathers-errors": "^2.8.2",
     "uberproto": "^1.2.0"
   },
   "devDependencies": {
+    "@feathersjs/express": "^1.1.2",
+    "@feathersjs/feathers": "^3.1.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.25.0",
     "babel-plugin-add-module-exports": "^0.2.1",
@@ -60,9 +62,6 @@
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-react": "^7.1.0",
-    "feathers": "^2.1.4",
-    "feathers-hooks": "^2.0.2",
-    "feathers-rest": "^1.8.0",
     "feathers-service-tests": "^0.10.2",
     "rimraf": "^2.6.1"
   }

--- a/src/error-handler.js
+++ b/src/error-handler.js
@@ -1,4 +1,4 @@
-import errors from 'feathers-errors'
+import errors from '@feathersjs/errors'
 
 export default function errorHandler(error) {
   let feathersError = error

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,8 @@ const _mapQueryParams = params => {
     let mappedParams = Object.assign({}, params);
     if (mappedParams.query) {
         mappedParams.selector = mappedParams.query;
+    } else {
+        return mappedParams;
     }
     if (mappedParams.selector.$limit) {
         mappedParams.limit = mappedParams.selector.$limit;

--- a/src/index.js
+++ b/src/index.js
@@ -1,178 +1,200 @@
 import Promise from 'bluebird'
 import Proto from 'uberproto'
-import errors from 'feathers-errors'
+import errors from '@feathersjs/errors'
 import errorHandler from './error-handler'
-import { mergeDeep, filterByKeys } from './util'
+import {mergeDeep, filterByKeys} from './util'
 
 const removeInvalidParams = params => {
-  const allowedParams = [
-    'selector', 'limit', 'skip', 'sort', 'fields', 'use_index',
-    'r', 'bookmark', 'update', 'stable', 'stale', 'execution_stats',
-    'conflicts', 'descending', 'endkey', 'end_key', 'endkey_docid',
-    'end_key_doc_id', 'include_docs', 'inclusive_end', 'key', 'keys',
-    'startkey', 'start_key', 'startkey_docid', 'start_key_doc_id',
-    'update_seq', 'options', 'filters', 'lists', 'rewrites', 'shows',
-    'updates', 'validate_doc_update', 'views',
-  ]
-  return filterByKeys(allowedParams, params)
+    const allowedParams = [
+        'selector', 'limit', 'skip', 'sort', 'fields', 'use_index',
+        'r', 'bookmark', 'update', 'stable', 'stale', 'execution_stats',
+        'conflicts', 'descending', 'endkey', 'end_key', 'endkey_docid',
+        'end_key_doc_id', 'include_docs', 'inclusive_end', 'key', 'keys',
+        'startkey', 'start_key', 'startkey_docid', 'start_key_doc_id',
+        'update_seq', 'options', 'filters', 'lists', 'rewrites', 'shows',
+        'updates', 'validate_doc_update', 'views',
+    ]
+    return filterByKeys(allowedParams, params)
+}
+
+const _mapQueryParams = params => {
+    let mappedParams = Object.assign({}, params);
+    if (mappedParams.query) {
+        mappedParams.selector = mappedParams.query;
+    }
+    if (mappedParams.selector.$limit) {
+        mappedParams.limit = mappedParams.selector.$limit;
+    }
+    if (mappedParams.selector.$skip) {
+        mappedParams.skip = mappedParams.selector.$skip;
+    }
+    if (mappedParams.selector.$sort) {
+        mappedParams.sort = mappedParams.selector.$sort;
+    }
+    if (mappedParams.selector.$select) {
+        mappedParams.fields = mappedParams.selector.$select;
+    }
+    return mappedParams;
 }
 
 class Service {
-  constructor(options) {
-    if (!options) {
-      throw new Error('CouchDB options have to be provided')
+    constructor(options) {
+        if (!options) {
+            throw new Error('CouchDB options have to be provided')
+        }
+
+        if (!('connection' in options)) {
+            throw new Error('You must provide CouchDB connection')
+        }
+
+        if (!('database' in options)) {
+            throw new Error('You must provide a database name')
+        }
+
+        this.connection = options.connection
+        this.database = options.database
+        this.paginate = options.paginate || {}
+
+        const create = Promise.promisify(this.connection.db.create)
+        const get = Promise.promisify(this.connection.db.get)
+
+        this.db = get(options.database)
+            .catch(() => create(options.database))
+            .catch(() => true) // always invoke next then
+            .then(() => Promise.promisifyAll(this.connection.use(options.database)))
     }
 
-    if (!('connection' in options)) {
-      throw new Error('You must provide CouchDB connection')
+    extend(obj) {
+        return Proto.extend(obj, this)
     }
 
-    if (!('database' in options)) {
-      throw new Error('You must provide a database name')
+    _list(params) {
+        return this.db.then(db => db.listAsync(params))
     }
 
-    this.connection = options.connection
-    this.database = options.database
-    this.paginate = options.paginate || {}
+    _view(designname, viewname, params) {
+        return this.db.then(db => db.viewAsync(designname, viewname, params))
+    }
 
-    const create = Promise.promisify(this.connection.db.create)
-    const get = Promise.promisify(this.connection.db.get)
+    _selector(params) {
+        return Promise.promisify(this.connection.request)({
+            method: 'POST',
+            doc: '_find',
+            db: this.database,
+            body: params,
+        })
+    }
 
-    this.db = get(options.database)
-      .catch(() => create(options.database))
-      .catch(() => true) // always invoke next then
-      .then(() => Promise.promisifyAll(this.connection.use(options.database)))
-  }
+    _get(id, params) {
+        return this.db.then(db => db.getAsync(id, params))
+    }
 
-  extend(obj) {
-    return Proto.extend(obj, this)
-  }
+    _insert(doc, params) {
+        return this.db
+            .then(db => db.insertAsync(doc, params))
+            .then(res => Object.assign(doc, {_id: res.id, _rev: res.rev}))
+    }
 
-  _list(params) {
-    return this.db.then(db => db.listAsync(params))
-  }
+    _bulk(docs, params) {
+        const assign = (data, res) => Object.assign(data, {_id: res.id, _rev: res.rev})
+        const bulkAssign = (arr, res) => arr.map((data, index) => assign(data, res[index]))
+        return this.db
+            .then(db => db.bulkAsync({docs}, params))
+            .then(res => bulkAssign(docs, res))
+    }
 
-  _view(designname, viewname, params) {
-    return this.db.then(db => db.viewAsync(designname, viewname, params))
-  }
+    _destroy(id, rev) {
+        return this.db.then(db => db.destroyAsync(id, rev))
+    }
 
-  _selector(params) {
-    return Promise.promisify(this.connection.request)({
-      method: 'POST',
-      doc: '_find',
-      db: this.database,
-      body: params,
-    })
-  }
-
-  _get(id, params) {
-    return this.db.then(db => db.getAsync(id, params))
-  }
-
-  _insert(doc, params) {
-    return this.db
-      .then(db => db.insertAsync(doc, params))
-      .then(res => Object.assign(doc, { _id: res.id, _rev: res.rev }))
-  }
-
-  _bulk(docs, params) {
-    const assign = (data, res) => Object.assign(data, { _id: res.id, _rev: res.rev })
-    const bulkAssign = (arr, res) => arr.map((data, index) => assign(data, res[index]))
-    return this.db
-      .then(db => db.bulkAsync({ docs }, params))
-      .then(res => bulkAssign(docs, res))
-  }
-
-  _destroy(id, rev) { return this.db.then(db => db.destroyAsync(id, rev)) }
-
-/**
- * @param params
- * @returns {object} {
+    /**
+     * @param params
+     * @returns {object} {
     "data": "<Array>"
     "total": "<total number of records>",
     "limit": "<max number of items per page>",
     "skip": "<number of skipped items (offset)>",
     "bookmark": "<alternative to skip>"
     }
-*/
-  find(params = {}) {
-    params.limit = params.limit || this.paginate.default
+     */
+    find(params = {}) {
+        params.limit = params.limit || this.paginate.default
 
-    const selector = params => {
-      return this._selector(removeInvalidParams(params))
-        .then(res => ({
-          limit: params.limit,
-          bookmark: res.bookmark,
-          data: res.docs,
-        }))
+        const selector = params => {
+            return this._selector(removeInvalidParams(_mapQueryParams(params)))
+                .then(res => ({
+                    limit: params.limit,
+                    bookmark: res.bookmark,
+                    data: res.docs,
+                }))
+        }
+
+        const view = params => {
+            return this._view(params.view.split('/')[0], params.view.split('/')[1], removeInvalidParams(params))
+        }
+
+        const list = params => {
+            return this._list(removeInvalidParams(params))
+        }
+
+        const viewOrList = params => {
+            return (params.view ? view(query) : list({...params, include_docs: true}))
+                .then(res => ({
+                    total: res.total_rows,
+                    limit: params.limit,
+                    skip: res.offset - 1,
+                    data: res.rows.map(row => row.doc),
+                }))
+        }
+
+        return (params.selector ? selector(params) : viewOrList(params))
+            .catch(errorHandler)
     }
 
-    const view = params => {
-      return this._view(params.view.split('/')[0], params.view.split('/')[1], removeInvalidParams(params))
+    get(id, params = {}) {
+        return this._get(id, removeInvalidParams(params)).catch(errorHandler)
     }
 
-    const list = params => {
-      return this._list(removeInvalidParams(params))
+    create(data, params = {}) {
+        return (
+            Array.isArray(data)
+                ? this._bulk(data, removeInvalidParams(params))
+                : this._insert(data, removeInvalidParams(params))
+        )
+            .catch(errorHandler)
     }
 
-    const viewOrList = params => {
-      return (params.view ? view(query) : list({...params, include_docs: true}))
-        .then(res => ({
-          total: res.total_rows,
-          limit: params.limit,
-          skip: res.offset - 1,
-          data: res.rows.map(row => row.doc),
-        }))
+    update(id, data, params = {include_docs: false}) {
+        if (Array.isArray(data) || id === null) {
+            return Promise.reject(new errors.BadRequest('Not replacing multiple records. Did you mean `patch`?'))
+        }
+
+        return this._get(id, removeInvalidParams(params))
+            .then(doc => (
+                Object.assign(data, {_rev: doc._rev}),
+                    this._insert(data, id).then(() => data)
+            ))
+            .catch(errorHandler)
     }
 
-    return (params.selector ? selector(params) : viewOrList(params))
-      .catch(errorHandler)
-  }
-
-  get(id, params = {}) {
-    return this._get(id, removeInvalidParams(params)).catch(errorHandler)
-  }
-
-  create(data, params = {}) {
-    return (
-      Array.isArray(data)
-      ? this._bulk(data, removeInvalidParams(params))
-      : this._insert(data, removeInvalidParams(params))
-    )
-    .catch(errorHandler)
-  }
-
-  update(id, data, params = { include_docs: false }) {
-    if (Array.isArray(data) || id === null) {
-      return Promise.reject(new errors.BadRequest('Not replacing multiple records. Did you mean `patch`?'))
+    patch(id, data, params = {}) {
+        return this._get(id, removeInvalidParams(params))
+            .then(doc => (
+                mergeDeep(doc, data),
+                    this._insert(doc, id)
+            ))
+            .catch(errorHandler)
     }
 
-    return this._get(id, removeInvalidParams(params))
-      .then(doc => (
-        Object.assign(data, { _rev: doc._rev }),
-        this._insert(data, id).then(() => data)
-      ))
-      .catch(errorHandler)
-  }
-
-  patch(id, data, params = {}) {
-    return this._get(id, removeInvalidParams(params))
-      .then(doc => (
-        mergeDeep(doc, data),
-        this._insert(doc, id)
-      ))
-      .catch(errorHandler)
-  }
-
-  remove(id, params = {}) {
-    return this._get(id, removeInvalidParams(params))
-      .then(doc => this._destroy(doc._id, doc._rev))
-      .catch(errorHandler)
-  }
+    remove(id, params = {}) {
+        return this._get(id, removeInvalidParams(params))
+            .then(doc => this._destroy(doc._id, doc._rev))
+            .catch(errorHandler)
+    }
 }
 
 export default function init(options) {
-  return new Service(options)
+    return new Service(options)
 }
 
 init.Service = Service

--- a/src/index.js
+++ b/src/index.js
@@ -5,199 +5,199 @@ import errorHandler from './error-handler'
 import {mergeDeep, filterByKeys} from './util'
 
 const removeInvalidParams = params => {
-    const allowedParams = [
-        'selector', 'limit', 'skip', 'sort', 'fields', 'use_index',
-        'r', 'bookmark', 'update', 'stable', 'stale', 'execution_stats',
-        'conflicts', 'descending', 'endkey', 'end_key', 'endkey_docid',
-        'end_key_doc_id', 'include_docs', 'inclusive_end', 'key', 'keys',
-        'startkey', 'start_key', 'startkey_docid', 'start_key_doc_id',
-        'update_seq', 'options', 'filters', 'lists', 'rewrites', 'shows',
-        'updates', 'validate_doc_update', 'views',
-    ]
-    return filterByKeys(allowedParams, params)
+  const allowedParams = [
+    'selector', 'limit', 'skip', 'sort', 'fields', 'use_index',
+    'r', 'bookmark', 'update', 'stable', 'stale', 'execution_stats',
+    'conflicts', 'descending', 'endkey', 'end_key', 'endkey_docid',
+    'end_key_doc_id', 'include_docs', 'inclusive_end', 'key', 'keys',
+    'startkey', 'start_key', 'startkey_docid', 'start_key_doc_id',
+    'update_seq', 'options', 'filters', 'lists', 'rewrites', 'shows',
+    'updates', 'validate_doc_update', 'views',
+  ]
+  return filterByKeys(allowedParams, params)
 }
 
 const _mapQueryParams = params => {
-    let mappedParams = Object.assign({}, params);
-    if (mappedParams.query) {
-        mappedParams.selector = mappedParams.query;
-    } else {
-        return mappedParams;
-    }
-    if (mappedParams.selector.$limit) {
-        mappedParams.limit = mappedParams.selector.$limit;
-    }
-    if (mappedParams.selector.$skip) {
-        mappedParams.skip = mappedParams.selector.$skip;
-    }
-    if (mappedParams.selector.$sort) {
-        mappedParams.sort = mappedParams.selector.$sort;
-    }
-    if (mappedParams.selector.$select) {
-        mappedParams.fields = mappedParams.selector.$select;
-    }
+  let mappedParams = Object.assign({}, params);
+  if (mappedParams.query) {
+    mappedParams.selector = mappedParams.query;
+  } else {
     return mappedParams;
+  }
+  if (mappedParams.selector.$limit) {
+    mappedParams.limit = mappedParams.selector.$limit;
+  }
+  if (mappedParams.selector.$skip) {
+    mappedParams.skip = mappedParams.selector.$skip;
+  }
+  if (mappedParams.selector.$sort) {
+    mappedParams.sort = mappedParams.selector.$sort;
+  }
+  if (mappedParams.selector.$select) {
+    mappedParams.fields = mappedParams.selector.$select;
+  }
+  return mappedParams;
 }
 
 class Service {
-    constructor(options) {
-        if (!options) {
-            throw new Error('CouchDB options have to be provided')
-        }
-
-        if (!('connection' in options)) {
-            throw new Error('You must provide CouchDB connection')
-        }
-
-        if (!('database' in options)) {
-            throw new Error('You must provide a database name')
-        }
-
-        this.connection = options.connection
-        this.database = options.database
-        this.paginate = options.paginate || {}
-
-        const create = Promise.promisify(this.connection.db.create)
-        const get = Promise.promisify(this.connection.db.get)
-
-        this.db = get(options.database)
-            .catch(() => create(options.database))
-            .catch(() => true) // always invoke next then
-            .then(() => Promise.promisifyAll(this.connection.use(options.database)))
+  constructor(options) {
+    if (!options) {
+      throw new Error('CouchDB options have to be provided')
     }
 
-    extend(obj) {
-        return Proto.extend(obj, this)
+    if (!('connection' in options)) {
+      throw new Error('You must provide CouchDB connection')
     }
 
-    _list(params) {
-        return this.db.then(db => db.listAsync(params))
+    if (!('database' in options)) {
+      throw new Error('You must provide a database name')
     }
 
-    _view(designname, viewname, params) {
-        return this.db.then(db => db.viewAsync(designname, viewname, params))
-    }
+    this.connection = options.connection
+    this.database = options.database
+    this.paginate = options.paginate || {}
 
-    _selector(params) {
-        return Promise.promisify(this.connection.request)({
-            method: 'POST',
-            doc: '_find',
-            db: this.database,
-            body: params,
-        })
-    }
+    const create = Promise.promisify(this.connection.db.create)
+    const get = Promise.promisify(this.connection.db.get)
 
-    _get(id, params) {
-        return this.db.then(db => db.getAsync(id, params))
-    }
+    this.db = get(options.database)
+      .catch(() => create(options.database))
+      .catch(() => true) // always invoke next then
+      .then(() => Promise.promisifyAll(this.connection.use(options.database)))
+  }
 
-    _insert(doc, params) {
-        return this.db
-            .then(db => db.insertAsync(doc, params))
-            .then(res => Object.assign(doc, {_id: res.id, _rev: res.rev}))
-    }
+  extend(obj) {
+    return Proto.extend(obj, this)
+  }
 
-    _bulk(docs, params) {
-        const assign = (data, res) => Object.assign(data, {_id: res.id, _rev: res.rev})
-        const bulkAssign = (arr, res) => arr.map((data, index) => assign(data, res[index]))
-        return this.db
-            .then(db => db.bulkAsync({docs}, params))
-            .then(res => bulkAssign(docs, res))
-    }
+  _list(params) {
+    return this.db.then(db => db.listAsync(params))
+  }
 
-    _destroy(id, rev) {
-        return this.db.then(db => db.destroyAsync(id, rev))
-    }
+  _view(designname, viewname, params) {
+    return this.db.then(db => db.viewAsync(designname, viewname, params))
+  }
 
-    /**
-     * @param params
-     * @returns {object} {
+  _selector(params) {
+    return Promise.promisify(this.connection.request)({
+      method: 'POST',
+      doc: '_find',
+      db: this.database,
+      body: params,
+    })
+  }
+
+  _get(id, params) {
+    return this.db.then(db => db.getAsync(id, params))
+  }
+
+  _insert(doc, params) {
+    return this.db
+      .then(db => db.insertAsync(doc, params))
+      .then(res => Object.assign(doc, {_id: res.id, _rev: res.rev}))
+  }
+
+  _bulk(docs, params) {
+    const assign = (data, res) => Object.assign(data, {_id: res.id, _rev: res.rev})
+    const bulkAssign = (arr, res) => arr.map((data, index) => assign(data, res[index]))
+    return this.db
+      .then(db => db.bulkAsync({docs}, params))
+      .then(res => bulkAssign(docs, res))
+  }
+
+  _destroy(id, rev) {
+    return this.db.then(db => db.destroyAsync(id, rev))
+  }
+
+  /**
+   * @param params
+   * @returns {object} {
     "data": "<Array>"
     "total": "<total number of records>",
     "limit": "<max number of items per page>",
     "skip": "<number of skipped items (offset)>",
     "bookmark": "<alternative to skip>"
     }
-     */
-    find(parameters = {}) {
-        let params = _mapQueryParams(parameters);
-        params.limit = params.limit || this.paginate.default;
+   */
+  find(parameters = {}) {
+    let params = _mapQueryParams(parameters);
+    params.limit = params.limit || this.paginate.default;
 
-        const selector = params => {
-            return this._selector(removeInvalidParams(params))
-                .then(res => ({
-                    limit: params.limit,
-                    bookmark: res.bookmark,
-                    data: res.docs,
-                }))
-        }
-
-        const view = params => {
-            return this._view(params.view.split('/')[0], params.view.split('/')[1], removeInvalidParams(params))
-        }
-
-        const list = params => {
-            return this._list(removeInvalidParams(params))
-        }
-
-        const viewOrList = params => {
-            return (params.view ? view(query) : list({...params, include_docs: true}))
-                .then(res => ({
-                    total: res.total_rows,
-                    limit: params.limit,
-                    skip: res.offset - 1,
-                    data: res.rows.map(row => row.doc),
-                }))
-        }
-
-        return (params.selector ? selector(params) : viewOrList(params))
-            .catch(errorHandler)
+    const selector = params => {
+      return this._selector(removeInvalidParams(params))
+        .then(res => ({
+          limit: params.limit,
+          bookmark: res.bookmark,
+          data: res.docs,
+        }))
     }
 
-    get(id, params = {}) {
-        return this._get(id, removeInvalidParams(params)).catch(errorHandler)
+    const view = params => {
+      return this._view(params.view.split('/')[0], params.view.split('/')[1], removeInvalidParams(params))
     }
 
-    create(data, params = {}) {
-        return (
-            Array.isArray(data)
-                ? this._bulk(data, removeInvalidParams(params))
-                : this._insert(data, removeInvalidParams(params))
-        )
-            .catch(errorHandler)
+    const list = params => {
+      return this._list(removeInvalidParams(params))
     }
 
-    update(id, data, params = {include_docs: false}) {
-        if (Array.isArray(data) || id === null) {
-            return Promise.reject(new errors.BadRequest('Not replacing multiple records. Did you mean `patch`?'))
-        }
-
-        return this._get(id, removeInvalidParams(params))
-            .then(doc => (
-                Object.assign(data, {_rev: doc._rev}),
-                    this._insert(data, id).then(() => data)
-            ))
-            .catch(errorHandler)
+    const viewOrList = params => {
+      return (params.view ? view(query) : list({...params, include_docs: true}))
+        .then(res => ({
+          total: res.total_rows,
+          limit: params.limit,
+          skip: res.offset - 1,
+          data: res.rows.map(row => row.doc),
+        }))
     }
 
-    patch(id, data, params = {}) {
-        return this._get(id, removeInvalidParams(params))
-            .then(doc => (
-                mergeDeep(doc, data),
-                    this._insert(doc, id)
-            ))
-            .catch(errorHandler)
+    return (params.selector ? selector(params) : viewOrList(params))
+      .catch(errorHandler)
+  }
+
+  get(id, params = {}) {
+    return this._get(id, removeInvalidParams(params)).catch(errorHandler)
+  }
+
+  create(data, params = {}) {
+    return (
+      Array.isArray(data)
+        ? this._bulk(data, removeInvalidParams(params))
+        : this._insert(data, removeInvalidParams(params))
+    )
+      .catch(errorHandler)
+  }
+
+  update(id, data, params = {include_docs: false}) {
+    if (Array.isArray(data) || id === null) {
+      return Promise.reject(new errors.BadRequest('Not replacing multiple records. Did you mean `patch`?'))
     }
 
-    remove(id, params = {}) {
-        return this._get(id, removeInvalidParams(params))
-            .then(doc => this._destroy(doc._id, doc._rev))
-            .catch(errorHandler)
-    }
+    return this._get(id, removeInvalidParams(params))
+      .then(doc => (
+        Object.assign(data, {_rev: doc._rev}),
+          this._insert(data, id).then(() => data)
+      ))
+      .catch(errorHandler)
+  }
+
+  patch(id, data, params = {}) {
+    return this._get(id, removeInvalidParams(params))
+      .then(doc => (
+        mergeDeep(doc, data),
+          this._insert(doc, id)
+      ))
+      .catch(errorHandler)
+  }
+
+  remove(id, params = {}) {
+    return this._get(id, removeInvalidParams(params))
+      .then(doc => this._destroy(doc._id, doc._rev))
+      .catch(errorHandler)
+  }
 }
 
 export default function init(options) {
-    return new Service(options)
+  return new Service(options)
 }
 
 init.Service = Service

--- a/src/index.js
+++ b/src/index.js
@@ -119,11 +119,12 @@ class Service {
     "bookmark": "<alternative to skip>"
     }
      */
-    find(params = {}) {
-        params.limit = params.limit || this.paginate.default
+    find(parameters = {}) {
+        let params = _mapQueryParams(parameters);
+        params.limit = params.limit || this.paginate.default;
 
         const selector = params => {
-            return this._selector(removeInvalidParams(_mapQueryParams(params)))
+            return this._selector(removeInvalidParams(params))
                 .then(res => ({
                     limit: params.limit,
                     bookmark: res.bookmark,


### PR DESCRIPTION
This PR adresses issues #8 and #9 .
-) Upgraded dependencies to Buzzard release
-) Increased release version number in package.json to be in the same range as the buzzard release
-) Mapped standard feathers query parameter to couchdb find api:
   -) query is mapped to selector
   -) $limit is mapped to limit under root element
   -) $skip is mapped to skip under root element
   -) $sort is mapped to sort under root element
   -) $select is mapped to fields under root element